### PR TITLE
Add support for Flutter 3.0 - Fix null-aware operation warning 

### DIFF
--- a/lib/measured_size.dart
+++ b/lib/measured_size.dart
@@ -26,13 +26,13 @@ class MeasuredSize extends StatefulWidget {
 class _MeasuredSizeState extends State<MeasuredSize> {
   @override
   void initState() {
-    SchedulerBinding.instance!.addPostFrameCallback(postFrameCallback);
+    SchedulerBinding.instance.addPostFrameCallback(postFrameCallback);
     super.initState();
   }
 
   @override
   Widget build(BuildContext context) {
-    SchedulerBinding.instance!.addPostFrameCallback(postFrameCallback);
+    SchedulerBinding.instance.addPostFrameCallback(postFrameCallback);
     return Container(
       key: widgetKey,
       child: widget.child,


### PR DESCRIPTION
On flutter 3.0 there's is a new warning added for null-aware operation, this removes the usage of the null-aware operation.

Warning:
```
../flutter/.pub-cache/hosted/pub.dartlang.org/measured_size-1.0.0/lib/measured_size.dart:29:22: Warning: Operand of null-aware operation
'!' has type 'SchedulerBinding' which excludes null.
 - 'SchedulerBinding' is from 'package:flutter/src/scheduler/binding.dart'
 ('../../../../flutter/packages/flutter/lib/src/scheduler/binding.dart').
    SchedulerBinding.instance!.addPostFrameCallback(postFrameCallback);
```